### PR TITLE
Make unbox casts cheap, make intorder free

### DIFF
--- a/src/Sharpl/Types/Core/ComparableTrait.cs
+++ b/src/Sharpl/Types/Core/ComparableTrait.cs
@@ -2,25 +2,9 @@ namespace Sharpl.Types.Core;
 
 public interface ComparableTrait
 {
-    static Order IntOrder(int value)
-    {
-        return value switch
-        {
-            < 0 => Order.LT,
-            > 0 => Order.GT,
-            _ => Order.EQ
-        };
-    }
+    static Order IntOrder(int value) => (Order)Math.Sign(value);
 
-    static int OrderInt(Order value)
-    {
-        return value switch
-        {
-            Order.LT => -1,
-            Order.GT => 1,
-            _ => 0,
-        };
-    }
+    static int OrderInt(Order value) => (int)value;
 
     Order Compare(Value left, Value right);
 };

--- a/src/Sharpl/Value.cs
+++ b/src/Sharpl/Value.cs
@@ -34,10 +34,18 @@ public readonly record struct Value(AnyType Type, object Data) : IComparable<Val
         Type == type ? Unsafe.As<T>(Data) : TypeMismatch(loc, Type, type);
 
     public T CastUnbox<T>(Type<T> type) where T : struct =>
-        Type == type ? Unsafe.Unbox<T>(Data) : TypeMismatch(Type, type);
+        Type == type ? Unsafe.As<StrongBox<T>>(Data).Value : TypeMismatch(Type, type);
 
     public T CastUnbox<T>(Loc loc, Type<T> type) where T : struct =>
-        Type == type ? Unsafe.Unbox<T>(Data) : TypeMismatch(loc, Type, type);
+        Type == type ? Unsafe.As<StrongBox<T>>(Data).Value : TypeMismatch(loc, Type, type);
+
+    // Do not remove Nullable<T> overloads - they are necessary
+    // to correctly handle unboxing of nullable structs.
+    public T? CastUnbox<T>(Type<T?> type) where T : struct =>
+        Type == type ? (T?)Data : TypeMismatch(Type, type);
+
+    public T? CastUnbox<T>(Loc loc, Type<T?> type) where T : struct =>
+        Type == type ? (T?)Data : TypeMismatch(loc, Type, type);
 
     public T CastSlow<T>(Type<T> type) =>
         Type == type ? (T)Data : TypeMismatch(Type, type);


### PR DESCRIPTION
There is something that was really bothering me about casts on primitive and struct values - despite upholding the type safety manually, there was still a helper call emitted for something that should have been a simple comparison and dereference of pointer + 0x08.

This is no longer the case - instead of calling into unbox helpers, we now reinterpret opaque object into a boxed representation of a struct we are about to unbox and directly read its value from memory. 

Performance impact is minor however as benchmarks are now bottlenecked elsewhere:
205 71 272 -> 205 70 257, shaves off about 10% execution time in Fibonacci Map
The generated assembly however is now much cleaner for unbox-heavy parts of the code.

To illustrate the problem, here's the comparison: https://godbolt.org/z/nqe66nb8E

Given what in `sharpl` is `Value` with `AnyType` being an `IntType` reference and an unbox call for `Type<int>` we get an asm similar\* to below. I have annotated some instructions so you can see what is exactly going on. Note that such calls are usually inlined and are slightly more compact in methods like `Eval()`.
```asm
Program:Old(Program+OpaqueBox,System.Object):int (FullOpts):
G_M9948_IG01:  ;; offset=0x0000
       push     rbp
       push     rbx
       push     rax
       lea      rbp, [rsp+0x10]
       mov      rbx, rsi
G_M9948_IG02:  ;; offset=0x000B
       ;; Compare object references between type objects
       cmp      rdi, rdx
       ;; If the comparison false, jump to a call to a throw helper at label IG06
       jne      SHORT G_M9948_IG06
       ;; load the TypeHandle.Value (aka MethodTable (managed VTable) pointer) of Int32 box
       mov      rsi, 0x7AF75D860928      ; System.Int32
       ;; compare with MT of the boxed integer we're about to unbox
       cmp      qword ptr [rbx], rsi
       ;; if true, jump over unbox helper call and load the integer at reference + 0x08 offset
       ;; this is because object references point to MethodTable of the object on heap
       ;; where-as the actual object contents start at reference + sizeof(pointer)
       je       SHORT G_M9948_IG04
G_M9948_IG03:  ;; offset=0x001F
       mov      rsi, rbx
       mov      rdi, 0x7AF75D860928      ; System.Int32
       ;; this call is predominantly needed to handle boxed nullable integers and other edge cases
       call     [CORINFO_HELP_UNBOX]
G_M9948_IG04:  ;; offset=0x0032
       ;; dereference the integer from our box
       mov      eax, dword ptr [rbx+0x08]
G_M9948_IG05:  ;; offset=0x0035
       add      rsp, 8
       pop      rbx
       pop      rbp
       ret      
G_M9948_IG06:  ;; offset=0x003C
       mov      rsi, rdi
       call     [Program+OpaqueBox:MismatchedType[int](System.Object,System.Object):int]
       int3     

Program:New(Program+OpaqueBox,System.Object):int (FullOpts):
G_M18951_IG01:  ;; offset=0x0000
       push     rax
G_M18951_IG02:  ;; offset=0x0001
       ;; Compare type objects same as before
       cmp      rdi, rdx
       ;; Conditional jump to throw helper
       jne      SHORT G_M18951_IG04
       ;; If check succeeded, immediately dereference our integer
       mov      eax, dword ptr [rsi+0x08]
G_M18951_IG03:  ;; offset=0x0009
       add      rsp, 8
       ret      
G_M18951_IG04:  ;; offset=0x000E
       mov      rsi, rdi
       call     [Program+OpaqueBox:MismatchedType[int](System.Object,System.Object):int]
       int3
```

\* this asm is similar to what JIT and ILC will emit in practice, but has slight difference. Notably, it seems that ILC (AOT) output sometimes does not have this fast path check to avoid unbox helper call, which we care about. Meanwhile JIT has its own cast profiling and optimizations for the common, often monomorphic, cast behaviors to speed this up. In either case, because `Value` and `Cast*` methods are quite hot and are the core abstraction for the LISP type system, this makes such kind of last-mile optimizations valuable. As you can see, C# gives a lot of freedom and a degree of control that makes it suitable even for systems programming tasks :)