### PR TITLE
Fix List.TryPop which would have been broken for structs, clean-up Form

### DIFF
--- a/src/Sharpl/List.cs
+++ b/src/Sharpl/List.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace Sharpl;
@@ -35,7 +36,7 @@ public static class List
     public static void Reverse(this Stack items, int n)
     {
         items.Reverse(items.Count - n, n);
-    }    
+    }
 
     public static string ToString<T>(List<T> items)
     {
@@ -66,7 +67,19 @@ public static class List
         return res.ToString();
     }
 
-    public static T? TryPop<T>(this List<T> items) => (items.Count == 0) ? default : Pop(items);
+    public static bool TryPop<T>(this List<T> items, [MaybeNullWhen(false)] out T? value)
+    {
+        if (items.Count > 0)
+        {
+            var i = items.Count - 1;
+            value = items[i];
+            items.RemoveAt(i);
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
 
     public static void Trunc<T>(this List<T> items, int n)
     {

--- a/src/Sharpl/VM.cs
+++ b/src/Sharpl/VM.cs
@@ -215,8 +215,7 @@ public class VM
                             s.Clear();
                         }
 
-                        var t = new Stopwatch();
-                        t.Start();
+                        var t = Stopwatch.GetTimestamp();
 
                         for (var i = 0; i < benchmarkOp.N; i++)
                         {
@@ -224,8 +223,8 @@ public class VM
                             s.Clear();
                         }
 
-                        t.Stop();
-                        stack.Push(Value.Make(Core.Int, (int)t.ElapsedMilliseconds));
+                        var e = Stopwatch.GetElapsedTime(t).TotalMilliseconds;
+                        stack.Push(Value.Make(Core.Int, (int)e));
                         break;
                     }
                 case Op.T.Branch:

--- a/src/Sharpl/VM.cs
+++ b/src/Sharpl/VM.cs
@@ -521,7 +521,7 @@ public class VM
                 case Op.T.PushListItem:
                     {
                         var pushOp = (Ops.PushListItem)op.Data;
-                        if (stack.TryPop() is Value v) { Get(pushOp.Target).Cast(pushOp.Loc, Core.List).Add(v); }
+                        if (stack.TryPop(out var v)) { Get(pushOp.Target).Cast(pushOp.Loc, Core.List).Add(v); }
                         else { throw new EvalError(pushOp.Loc, "Missing target"); }
                         PC++;
                         break;
@@ -635,7 +635,7 @@ public class VM
                     {
                         var unzipOp = (Ops.Unzip)op.Data;
                         
-                        if (stack.TryPop() is Value p)
+                        if (stack.TryPop(out var p))
                         {
                             var pv = p.CastUnbox(Core.Pair);
                             stack.Push(pv.Item1);


### PR DESCRIPTION
This PR fixes `List.TryPop` which would have always returned `true` for structs when combined with `is` pattern that was used with it. Also makes it the same as every other `Try*` pattern in .NET under the sun :)

Given that `Form` too has similar pattern - the PR makes it a bit more standard. Given it is used quite prominently throughout sharpl and will work on Form which is a class, I erred to leave its signature as is but ideally it could match the List one.

Last but not least I wanted to add two notes:

- I like sharpl and naturally it is your project only so I have no expectation that there will be some kind of fix when I leave comments on commits. These are intended to simply showcase the terser ways that C# offers, something to keep in mind and make use of if it makes sense to you - not a call to action

- Main bytecode interpreter loop https://github.com/codr7/sharpl/blob/main/src/Sharpl/VM.cs#L188 has gotten dangerously close to compiler limits. It currently sits around 11KiB of machine code (which is a lot - x86 CPUs tend to have just 32KiB of L1i cache, this method is *big*) , has about 375 inlinee blocks and most importantly 936-955 tracked locals depending on compiler version and platform targeted.

Why does this matter?

.NET's RyuJIT (I wish it had some non-JIT name but it's the same back-end that serves native AOT compilation) can optimally track at most 1000 locals. Once it reaches this limit, it starts quickly regressing in codegen quality, eventually reaching the debug levels of deoptimization. In order to mitigate this, it has complex budgeting model that does things like reducing inlining. But because the method body is naturally large - it can only do so much.

In order to address this, I suggest refactoring out rarely taken or naturally large arms of the switch into separate methods. Possible candidates are `Op.T.Benchmark` and `Op.T.OpenInputStream`. This means having the switch arm but just calling a method there instead of having the body inline.